### PR TITLE
Rename the Python SDK package from `sindri-labs` to `sindri`

### DIFF
--- a/circuit_tutorials/circom/food_ml/README.md
+++ b/circuit_tutorials/circom/food_ml/README.md
@@ -40,7 +40,7 @@ _________________________________________________________________
    ```bash
    export SINDRI_API_KEY=<YOUR_API_KEY>
    ```
-1. Install requirements: `pip install sindri-labs`
+1. Install requirements: `pip install sindri`
 
 ### Run
 Running the following command will create a circuit and prove it (i.e. the model defined in the `circuit/`) using the Python Sindri SDK.

--- a/circuit_tutorials/circom/food_ml/compile_and_prove.py
+++ b/circuit_tutorials/circom/food_ml/compile_and_prove.py
@@ -3,7 +3,7 @@ import json
 import os
 import sys
 
-from sindri_labs.sindri import Sindri  # pip install sindri-labs
+from sindri.sindri import Sindri  # pip install sindri
 
 # NOTE: Provide your API Key and API Url
 API_KEY = os.getenv("SINDRI_API_KEY", "")

--- a/circuit_tutorials/halo2/axiom-v0.2.2/storage_proof/compile_and_prove.py
+++ b/circuit_tutorials/halo2/axiom-v0.2.2/storage_proof/compile_and_prove.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 import os
 
-from sindri_labs.sindri import Sindri  # pip install sindri-labs
+from sindri.sindri import Sindri  # pip install sindri
 
 # NOTE: Provide your API Key and API Url
 API_KEY = os.getenv("SINDRI_API_KEY", "")

--- a/reference_code/README.md
+++ b/reference_code/README.md
@@ -14,7 +14,7 @@ This directory contains scripts and demonstrations generating, deploying, and in
 # SDK Quickstart
 
 [`sdk_quickstart.py`](./sdk_quickstart.py) is for users that are just getting started using Sindri's API.
-It utilizes the [Sindri Python SDK](https://pypi.org/project/sindri-labs/), which abstracts Sindri API calls into a simple interface.
+It utilizes the [Sindri Python SDK](https://pypi.org/project/sindri/), which abstracts Sindri API calls into a simple interface.
 
 Refer to the Sindri documentation for quickly [getting started with the Python SDK](https://sindri.app/docs/getting-started/api-sdk/).
 

--- a/reference_code/sdk_quickstart.py
+++ b/reference_code/sdk_quickstart.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 import os
-from sindri_labs.sindri import Sindri  # pip install sindri-labs
+from sindri.sindri import Sindri  # pip install sindri
 
 # Obtain your API Key from an environment variable
 API_KEY = os.getenv("SINDRI_API_KEY", "")

--- a/reference_code/verifiers/circom/solidity/README.md
+++ b/reference_code/verifiers/circom/solidity/README.md
@@ -20,10 +20,10 @@ Before running any of the python scripts in this directory, you should set your 
 export SINDRI_API_KEY=<YOUR_API_KEY>
 ```
 
-Finally, ensure that you have the `sindri-labs` python SDK installed.
+Finally, ensure that you have the `sindri` python SDK installed.
 The [Python SDK Quickstart](https://sindri.app/docs/getting-started/api-sdk/#python-sdk) contains installation instructions and a high-level walkthrough of the functionality of this package, but the following will suffice if you have pip installed:
 ```
-pip install sindri-labs
+pip install sindri
 ```
 
 ## Prepare the circuit and contract

--- a/reference_code/verifiers/circom/solidity/compile_sol.py
+++ b/reference_code/verifiers/circom/solidity/compile_sol.py
@@ -2,7 +2,7 @@ import os
 import json
 import subprocess
 
-from sindri_labs.sindri import Sindri  # pip install sindri-labs
+from sindri.sindri import Sindri  # pip install sindri
 
 
 # Initialize an instance of the Sindri API SDK

--- a/reference_code/verifiers/circom/solidity/prove_verify.py
+++ b/reference_code/verifiers/circom/solidity/prove_verify.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import os
 import subprocess
-from sindri_labs.sindri import Sindri  # pip install sindri-labs
+from sindri.sindri import Sindri  # pip install sindri
 
 parser = argparse.ArgumentParser(description="Process circuit_id argument.")
 parser.add_argument("--circuit_id", type=str, help="The circuit ID to use")


### PR DESCRIPTION
New package: https://pypi.org/project/sindri/
