### PR TITLE
Import `Sindri` client from the Python SDK

### DIFF
--- a/circuit_tutorials/circom/food_ml/compile_and_prove.py
+++ b/circuit_tutorials/circom/food_ml/compile_and_prove.py
@@ -3,7 +3,7 @@ import json
 import os
 import sys
 
-from sindri.sindri import Sindri  # pip install sindri
+from sindri import Sindri  # pip install sindri
 
 # NOTE: Provide your API Key and API Url
 API_KEY = os.getenv("SINDRI_API_KEY", "")

--- a/circuit_tutorials/halo2/axiom-v0.2.2/storage_proof/compile_and_prove.py
+++ b/circuit_tutorials/halo2/axiom-v0.2.2/storage_proof/compile_and_prove.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 import os
 
-from sindri.sindri import Sindri  # pip install sindri
+from sindri import Sindri  # pip install sindri
 
 # NOTE: Provide your API Key and API Url
 API_KEY = os.getenv("SINDRI_API_KEY", "")

--- a/reference_code/sdk_quickstart.py
+++ b/reference_code/sdk_quickstart.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 import os
-from sindri.sindri import Sindri  # pip install sindri
+from sindri import Sindri  # pip install sindri
 
 # Obtain your API Key from an environment variable
 API_KEY = os.getenv("SINDRI_API_KEY", "")

--- a/reference_code/verifiers/circom/solidity/compile_sol.py
+++ b/reference_code/verifiers/circom/solidity/compile_sol.py
@@ -2,7 +2,7 @@ import os
 import json
 import subprocess
 
-from sindri.sindri import Sindri  # pip install sindri
+from sindri import Sindri  # pip install sindri
 
 
 # Initialize an instance of the Sindri API SDK

--- a/reference_code/verifiers/circom/solidity/prove_verify.py
+++ b/reference_code/verifiers/circom/solidity/prove_verify.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import os
 import subprocess
-from sindri.sindri import Sindri  # pip install sindri
+from sindri import Sindri  # pip install sindri
 
 parser = argparse.ArgumentParser(description="Process circuit_id argument.")
 parser.add_argument("--circuit_id", type=str, help="The circuit ID to use")


### PR DESCRIPTION
We were previously importing `Sindri` from the `sindri.sindri` submodule, but it's now re-exported from the top-level module so we can use the slightly cleaner `from sindri import Sindri` form.
