### PR TITLE
Update Python SDK Getting Started Guide Links

### DIFF
--- a/reference_code/README.md
+++ b/reference_code/README.md
@@ -16,7 +16,7 @@ This directory contains scripts and demonstrations generating, deploying, and in
 [`sdk_quickstart.py`](./sdk_quickstart.py) is for users that are just getting started using Sindri's API.
 It utilizes the [Sindri Python SDK](https://pypi.org/project/sindri/), which abstracts Sindri API calls into a simple interface.
 
-Refer to the Sindri documentation for quickly [getting started with the Python SDK](https://sindri.app/docs/getting-started/api-sdk/).
+Refer to the Sindri documentation for quickly [getting started with the Python SDK](https://sindri.app/docs/getting-started/python-sdk/).
 
 # Quick-Start Scripts
 

--- a/reference_code/verifiers/circom/solidity/README.md
+++ b/reference_code/verifiers/circom/solidity/README.md
@@ -23,7 +23,7 @@ export SINDRI_API_KEY=<YOUR_API_KEY>
 ```
 
 Finally, ensure that you have the `sindri` python SDK installed.
-The [Python SDK Quickstart](https://sindri.app/docs/getting-started/api-sdk/#python-sdk) contains installation instructions and a high-level walkthrough of the functionality of this package, but the following will suffice if you have pip installed:
+The [Python SDK Quickstart](https://sindri.app/docs/getting-started/python-sdk/#python-sdk) contains installation instructions and a high-level walkthrough of the functionality of this package, but the following will suffice if you have pip installed:
 
 ```
 pip install sindri


### PR DESCRIPTION
Now that we have multiple SDK starting guides, the Python one has been moved to a more specific URL route. This PR updates the existing links in the repo.
