### PR TITLE
Patch to Rust Quickstart

### DIFF
--- a/reference_code/quickstart_rust/README.md
+++ b/reference_code/quickstart_rust/README.md
@@ -1,9 +1,9 @@
 # Rust Quickstart
 
-The code in `src/main.rs` will create a circuit, upload, and initiate compilation. Then from that compiled circuit, it will initiate a proof. From this directory, you can call
-```bash
-cargo run
-```
-which builds the executable and runs it.
+This rust quickstart provides a minimal example of compiling and proving a circuit with Sindri's API via the [reqwest](https://docs.rs/reqwest/latest/reqwest/) HTTP request client.
 
-**DISCLAIMER:** This code does minimal return code processing and could be improved to return proofs or keys to a user.
+## Usage 
+Assuming you are in the `/reference_code/quickstart_rust/` directory, you can build and run the main the package via 
+```
+SINDRI_API_KEY=<your-api-key> cargo run
+```

--- a/reference_code/quickstart_rust/src/main.rs
+++ b/reference_code/quickstart_rust/src/main.rs
@@ -1,50 +1,53 @@
-use std::{
-    io::Cursor,
-    option_env,
-    time::Duration
-};
-use flate2::Compression;
 use flate2::write::GzEncoder;
+use flate2::Compression;
 use reqwest::{
-    Client, 
     header::{HeaderMap, HeaderValue},
-    multipart::Part
+    multipart::Part,
+    Client,
 };
 use serde_json::Value;
+use std::{io::Cursor, option_env, time::Duration};
 
 // Functions which return Reqwest Header
 fn headers_json(api_key: &str) -> HeaderMap {
     let mut headers_json = HeaderMap::new();
     headers_json.insert("Accept", "application/json".parse().unwrap());
-    headers_json.insert("Authorization", HeaderValue::from_str(&format!("Bearer {api_key}").to_string()).unwrap());
+    headers_json.insert(
+        "Authorization",
+        HeaderValue::from_str(&format!("Bearer {api_key}").to_string()).unwrap(),
+    );
     headers_json
 }
 
 // Polling loop while circuit compile or proof is in progress
-async fn poll_status(
-    endpoint: String, 
-    api_url: &str,
-    api_key: &str,
-    timeout: i64
-) -> Value {
+async fn poll_status(endpoint: String, api_url: &str, api_key: &str, timeout: i64) -> Value {
     let client = Client::new();
     for i in 1..timeout {
-
         let response = client
-        .get(format!("{api_url}{endpoint}"))
-        .headers(headers_json(api_key))
-        .send()
-        .await
-        .unwrap();
-        assert_eq!(&response.status().as_u16(), &200u16, "Expected status code 201");
-    
+            .get(format!("{api_url}{endpoint}"))
+            .headers(headers_json(api_key))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            &response.status().as_u16(),
+            &200u16,
+            "Expected status code 201"
+        );
+
         let data = response.json::<Value>().await.unwrap();
         let status = &data["status"].to_string();
-        if ["Ready", "Failed"].iter().any(|&s| status.as_str().contains(s))  {
-            println!("Polling exited after {} seconds with status: {}", i, &status);
-            return data
+        if ["Ready", "Failed"]
+            .iter()
+            .any(|&s| status.as_str().contains(s))
+        {
+            println!(
+                "Polling exited after {} seconds with status: {}",
+                i, &status
+            );
+            return data;
         }
-        
+
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
 
@@ -54,19 +57,20 @@ async fn poll_status(
 
 #[tokio::main]
 async fn main() {
-
     let api_key: &str = option_env!("SINDRI_API_KEY").unwrap_or("");
     let api_url_prefix: &str = option_env!("SINDRI_API_URL").unwrap_or("https://sindri.app/api/");
-    
+
     let api_version: &str = "v1/";
-    let api_url: String = api_url_prefix.to_owned()  + api_version;
+    let api_url: String = api_url_prefix.to_owned() + api_version;
 
     let mut contents = Vec::new();
-    { // has to be scoped so that contents can be accessed after written to
+    {
+        // has to be scoped so that contents can be accessed after written to
         let buffer = Cursor::new(&mut contents);
         let enc = GzEncoder::new(buffer, Compression::default());
         let mut tar = tar::Builder::new(enc);
-        tar.append_dir_all("multiplier2/","../../circuit_database/circom/multiplier2/").unwrap();
+        tar.append_dir_all("multiplier2/", "../../circuit_database/circom/multiplier2/")
+            .unwrap();
     }
     let part = Part::bytes(contents).file_name("filename.filetype");
     let upload = reqwest::multipart::Form::new().part("files", part);
@@ -81,21 +85,27 @@ async fn main() {
         .send()
         .await
         .unwrap();
-    assert_eq!(&response.status().as_u16(), &201u16, "Expected status code 201");
+    assert_eq!(
+        &response.status().as_u16(),
+        &201u16,
+        "Expected status code 201"
+    );
     let response_body = response.json::<Value>().await.unwrap();
-    let circuit_id = response_body["circuit_id"].as_str().unwrap(); 
+    let circuit_id = response_body["circuit_id"].as_str().unwrap();
 
     // Poll circuit detail until it has a status of Ready or Failed
     let circuit_data = poll_status(
         format!("circuit/{circuit_id}/detail"),
         &api_url,
         api_key,
-        600).await;
+        600,
+    )
+    .await;
     if circuit_data["status"].as_str().unwrap().contains("Failed") {
         println!("Circuit compilation failed.");
         std::process::exit(1);
     }
-    println!("Circuit compilation succeeded!");    
+    println!("Circuit compilation succeeded!");
 
     // Initiate proof generation.
     println!("2. Proving circuit...");
@@ -109,17 +119,17 @@ async fn main() {
         .send()
         .await
         .unwrap();
-    assert_eq!(&response.status().as_u16(), &201u16, "Expected status code 201");
-    
+    assert_eq!(
+        &response.status().as_u16(),
+        &201u16,
+        "Expected status code 201"
+    );
+
     let response_body = response.json::<Value>().await.unwrap();
     let proof_id = response_body["proof_id"].as_str().unwrap();
 
     // Poll proof detail until it has a status of Ready or Failed
-    let proof_data = poll_status(
-        format!("proof/{proof_id}/detail"),
-        &api_url,
-        api_key,
-        600).await;
+    let proof_data = poll_status(format!("proof/{proof_id}/detail"), &api_url, api_key, 600).await;
     if proof_data["status"].as_str().unwrap().contains("Failed") {
         println!("Proving failed.");
         std::process::exit(1);
@@ -128,5 +138,4 @@ async fn main() {
     // Retrieve output from the proof.
     let output_signal = &proof_data["public"];
     println!("Circuit proof output signal: {}", output_signal);
-
 }


### PR DESCRIPTION
This PR restores the rust quickstart functionality.

## Testing Instructions
You can run the rust quickstart the same as previous instructions:
```
cd reference_code/quickstart rust
SINDRI_API_KEY=... cargo run
```
You should see the output of compile and proving (if you tried this with the current main branch, you'd hit a runtime error during the first iteration of the compile polling loop.)

## Bug Source
With the new public circuits feature, we introduced the "public" field to the circuit detail response.  That was problematic with the previous quickstart because there was a struct that assumed the public field would only be returned as a vec (i.e. from the proof detail response), otherwise it would not be found.  That allowed one function to poll both the circuit and proof status without defining an enum to capture both response schemas.  

## Solution
Since this is the quickstart, defining a verbose enum that elaborates on the entire response schemas seemed too in-depth.  Rather, the poll response is now captured in the `serde_json::Value` type.  The value type is used as a wild-card when you don't really know what JSON responses will come back until runtime.  Not the right choice for production or an SDK - but I do think it's a good fit for a quickstart template.