### PR TITLE
Fixing Axiom v3 Tutorial Verifier

### DIFF
--- a/circuit_tutorials/halo2/axiom-v0.3.0/float_radius/zk_execute/src/bin/verify.rs
+++ b/circuit_tutorials/halo2/axiom-v0.3.0/float_radius/zk_execute/src/bin/verify.rs
@@ -53,7 +53,7 @@ async fn main() {
 
     // download SRS if it doesn't exist in ./data already
     if !std::path::Path::new("./data/kzg_bn254_15.srs").is_file() {
-        let srs_link = "https://axiom-crypto.s3.amazonaws.com/params/kzg_bn254_15.srs";
+        let srs_link = "https://axiom-crypto.s3.amazonaws.com/challenge_0085/kzg_bn254_15.srs";
         let response = reqwest::get(srs_link).await.unwrap();
         let mut file = std::fs::File::create("./data/kzg_bn254_15.srs").unwrap();
         let mut content =  Cursor::new(response.bytes().await.unwrap());


### PR DESCRIPTION
This updates a broken S3 link in order to grab the appropriate trusted setup file so that users can locally verify a halo2 proof.

## Testing Instructions
First, make sure that you don't already have a file called `circuit_tutorials/halo2/axiom-v0.3.0/float_radius/data/kzg_bn254_15.srs`.  Otherwise, the link replacement will not be tested.  Then, replace the api key field in the code block below and run the following:
```
cd circuit_tutorials/halo2/axiom-v0.3.0/float_radius
export SINDRI_API_KEY=<your-api-key>
cargo run --bin compile
cargo run --bin prove
cargo run --bin verify
```

If you tried the above with the main branch, you'd see a rust runtime error, but now the final output line should be `Verification Successful!`.  That will confirm you have successfully pulled from the new location and verified a Sindri proof.