### PR TITLE
Plonky2 sindri.json lint fix

### DIFF
--- a/circuit_database/plonky2/fibonacci/sindri.json
+++ b/circuit_database/plonky2/fibonacci/sindri.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://sindri.app/api/v1/sindri-manifest-schema.json",
   "name": "fibonacci_circuit",
   "circuitType": "plonky2",
   "structName": "fibonacci::FibonacciCircuit",

--- a/circuit_database/plonky2/fibonacci/sindri.json
+++ b/circuit_database/plonky2/fibonacci/sindri.json
@@ -1,8 +1,8 @@
 {
-    "name": "fibonacci_circuit",
-    "circuitType": "plonky2",
-    "structName": "fibonacci::FibonacciCircuit",
-    "plonky2Version": "0.2.2",
-    "provingScheme": "plonky2",
-    "packageName": "fibonacci"
-  }
+  "name": "fibonacci_circuit",
+  "circuitType": "plonky2",
+  "structName": "fibonacci::FibonacciCircuit",
+  "plonky2Version": "0.2.2",
+  "provingScheme": "plonky2",
+  "packageName": "fibonacci"
+}

--- a/circuit_database/plonky2/hashes/sindri.json
+++ b/circuit_database/plonky2/hashes/sindri.json
@@ -1,9 +1,9 @@
 {
-    "name": "hash_circuit",
-    "circuitType": "plonky2",
-    "structName": "hash_circuit::HashCircuit",
-    "plonky2Version": "0.2.2",
-    "provingScheme": "plonky2",
-    "packageName": "hash_circuit"
-  }
+  "name": "hash_circuit",
+  "circuitType": "plonky2",
+  "structName": "hash_circuit::HashCircuit",
+  "plonky2Version": "0.2.2",
+  "provingScheme": "plonky2",
+  "packageName": "hash_circuit"
+}
   

--- a/circuit_database/plonky2/hashes/sindri.json
+++ b/circuit_database/plonky2/hashes/sindri.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://sindri.app/api/v1/sindri-manifest-schema.json",
   "name": "hash_circuit",
   "circuitType": "plonky2",
   "structName": "hash_circuit::HashCircuit",
@@ -6,4 +7,3 @@
   "provingScheme": "plonky2",
   "packageName": "hash_circuit"
 }
-  


### PR DESCRIPTION
Plonky2 sindri.json lint fix

- Added the `"$schema": "https://sindri.app/api/v1/sindri-manifest-schema.json"` line to the sindri.json files so editors can provide live feedback on the files.
- The sindri.json files raised CI format errors.