### PR TITLE
Axiom v2 Circuit Tutorial Maintanence

### DIFF
--- a/circuit_tutorials/halo2/axiom-v0.2.2/storage_proof/circuit/Cargo.toml
+++ b/circuit_tutorials/halo2/axiom-v0.2.2/storage_proof/circuit/Cargo.toml
@@ -41,6 +41,7 @@ snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier.git
 
 # generating circuit inputs from blockchain
 ethers-providers = { version = "1.0.2", optional = true }  
+tokio-util = "=0.7.0"
 tokio = { version = "1.23.0", default-features = false, features = ["rt", "rt-multi-thread"], optional = true }
 
 [dev-dependencies]

--- a/circuit_tutorials/halo2/axiom-v0.2.2/storage_proof/compile_and_prove.py
+++ b/circuit_tutorials/halo2/axiom-v0.2.2/storage_proof/compile_and_prove.py
@@ -5,10 +5,9 @@ from sindri import Sindri  # pip install sindri
 
 # NOTE: Provide your API Key and API Url
 API_KEY = os.getenv("SINDRI_API_KEY", "")
-API_URL = os.getenv("SINDRI_API_URL", "https://sindri.app/api/")
 
 # Initialize Sindri API SDK
-sindri = Sindri(API_KEY, api_url=API_URL, verbose_level=1)
+sindri = Sindri(API_KEY, verbose_level=1)
 
 # Create the circuit
 circuit_upload_path = "circuit/"


### PR DESCRIPTION
This pins a version of `tokio-utils` that is satisfied with the rust toolchain used by the Axiom v0.2.2 prover.  Moreover, a deprecated python-SDK argument has been removed from the example code provided with this circuit.

## Reviewer Testing Instructions
Ensure you have a fairly recent version of the Sindri python SDK.  Then enter your production environment API key and run the codeblock below. You should see a successful compile and prove job indicated in the output
```
cd circuit_tutorials/halo2/axiom-v0.2.2/storage_proof/
export SINDRI_API_KEY=<key-here>
./compile_and_prove.py
```
